### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -54,7 +54,8 @@
         <de.grobox.blitzmail.EncryptedEditTextPreference
             android:title="@string/pref_smtp_pass"
             android:key="pref_smtp_pass"
-            android:inputType="textPassword"/>
+            android:inputType="textPassword"
+            android:importantForAccessibility="no"/>
         
     </PreferenceCategory>
 


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.