### PR TITLE
Allow usage of STARTTLS/SSL without enabling authentication

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -4,7 +4,7 @@
 
     <string-array name="encryption" translatable="false">
         <item name="none">None</item>
-        <item name="tls">TLS</item>
+        <item name="tls">STARTTLS</item>
         <item name="ssl">SSL</item>
     </string-array>
     

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -36,17 +36,17 @@
             android:key="pref_smtp_port"
             android:inputType="number"
             android:defaultValue="25"/>
+        <ListPreference
+            android:title="@string/pref_smtp_encryption"
+            android:key="pref_smtp_encryption"
+            android:entries="@array/encryption"
+            android:entryValues="@array/encryptionValues" android:defaultValue="none"/>
         <CheckBoxPreference
             android:title="@string/pref_smtp_auth"
             android:key="pref_smtp_auth"
             android:defaultValue="false"
             android:summaryOff="@string/pref_summary_smtp_auth_off"
             android:summaryOn="@string/pref_summary_smtp_auth_on"/>
-        <ListPreference
-            android:title="@string/pref_smtp_encryption"
-            android:key="pref_smtp_encryption"
-            android:entries="@array/encryption"
-            android:entryValues="@array/encryptionValues" android:defaultValue="none"/>
         <EditTextPreference
             android:title="@string/pref_smtp_user"
             android:inputType="textNoSuggestions"

--- a/src/de/grobox/blitzmail/preferences/MailPreferences.kt
+++ b/src/de/grobox/blitzmail/preferences/MailPreferences.kt
@@ -19,6 +19,7 @@ fun getProperties(c: Context): Properties {
 
     val server = pref.getString("pref_smtp_server", null)
     val port = pref.getString("pref_smtp_port", null)
+    val encryption = pref.getString("pref_smtp_encryption", null)
     val auth = pref.getBoolean("pref_smtp_auth", false)
     val user = pref.getString("pref_smtp_user", null)
     var password = pref.getString("pref_smtp_pass", null)
@@ -51,19 +52,20 @@ fun getProperties(c: Context): Properties {
         // set username and password
         props.setProperty("mail.smtp.user", user)
         props.setProperty("mail.smtp.pass", password)
-
-        // set encryption properties
-        if (pref.getString("pref_smtp_encryption", "") == "ssl") {
-            Log.i("SendActivity", "Using SSL Encryption...")
-            props.setProperty("mail.smtp.ssl.enable", "true")
-        } else if (pref.getString("pref_smtp_encryption", "") == "tls") {
-            Log.i("SendActivity", "Using TLS Encryption...")
-            props.setProperty("mail.smtp.starttls.enable", "true")
-        }
-        props.setProperty("mail.smtp.ssl.checkserveridentity", "true")
     } else {
         // set some hostname for proper HELO greeting
         props.setProperty("mail.smtp.localhost", "android.com")
+    }
+
+    // set encryption properties
+    if (encryption == "ssl") {
+        Log.i("SendActivity", "Using SSL Encryption...")
+        props.setProperty("mail.smtp.ssl.enable", "true")
+        props.setProperty("mail.smtp.ssl.checkserveridentity", "true")
+    } else if (encryption == "tls") {
+        Log.i("SendActivity", "Using STARTTLS Encryption...")
+        props.setProperty("mail.smtp.starttls.enable", "true")
+        props.setProperty("mail.smtp.ssl.checkserveridentity", "true")
     }
 
     // try to get proper hostname and set fake one if failed

--- a/src/de/grobox/blitzmail/preferences/PrefFragment.java
+++ b/src/de/grobox/blitzmail/preferences/PrefFragment.java
@@ -60,11 +60,9 @@ public class PrefFragment extends PreferenceFragment implements OnSharedPreferen
 	private void setPrefState() {
 		CheckBoxPreference authPref = (CheckBoxPreference) findPreference("pref_smtp_auth");
 		if(authPref.isChecked()) {
-			findPreference("pref_smtp_encryption").setEnabled(true);
 			findPreference("pref_smtp_user").setEnabled(true);
 			findPreference("pref_smtp_pass").setEnabled(true);
 		} else {
-			findPreference("pref_smtp_encryption").setEnabled(false);
 			findPreference("pref_smtp_user").setEnabled(false);
 			findPreference("pref_smtp_pass").setEnabled(false);
 		}


### PR DESCRIPTION
This patch makes the SMTP encryption (STARTTLS/SSL) setting independent of authentication.

I did my best to update the translations but a quick review would be appreciated!
