### PR TITLE
Always fill in subject when missing/empty EXTRA_SUBJECT

### DIFF
--- a/src/de/grobox/blitzmail/send/SendActivity.java
+++ b/src/de/grobox/blitzmail/send/SendActivity.java
@@ -134,7 +134,7 @@ public class SendActivity extends AppCompatActivity {
 			String cc = intent.getStringExtra(Intent.EXTRA_CC);
 
 			// Check for empty content
-			if(subject == null) {
+			if(subject == null || subject.isEmpty()) {
 				// cut all characters from subject after the 128th
 				subject = text.substring(0, (text.length() < 128) ? text.length() : 128);
 				// remove line breaks from subject


### PR DESCRIPTION
BlitzMail sets the email subject to part of EXTRA_TEXT if EXTRA_SUBJECT is null (ie missing from parcel) when it receives a text note. This patch makes BlitzMail do the same when EXTRA_SUBJECT is present but empty.

Many applications always set EXTRA_SUBJECT to "" (empty string):
- DuckDuckGo: When sharing a link the EXTRA_SUBJECT is always "" resulting in empty mail subject.
- Firefox Focus: When sharing a link the EXTRA_SUBJECT is always "" resulting in empty mail subject.
- Google Keep: When sharing a note the EXTRA_SUBJECT may be "" if the note has no title (Keep itself would display it from the note's text)
