### PR TITLE
Change the mail subject when sharing a file to something more consise

### DIFF
--- a/res/values/plurals.xml
+++ b/res/values/plurals.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <plurals name="files_shared">
-        <item quantity="one">File: %3$s</item>
-        <item quantity="other">Files: %3$s and %2$d more</item>
-    </plurals>
-
-</resources>

--- a/res/values/plurals.xml
+++ b/res/values/plurals.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <plurals name="files_shared">
+        <item quantity="one">File: %3$s</item>
+        <item quantity="other">Files: %3$s and %2$d more</item>
+    </plurals>
+
+</resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -47,12 +47,8 @@
     <string name="pref_success_notification">Show Notification for Sent Mail</string>
     <string name="pref_summary_success_notification_on">Show notification in status bar after mail has been sent</string>
     <string name="pref_summary_success_notification_off">Don\'t show notification in status bar after mail has been sent</string>
-    <string name="files_shared">File(s) shared with</string>
     <string name="save">Save</string>
     <string name="warning_nothing_to_send">Nothing to send</string>
     <string name="mail_queued">Mail will be send when online</string>
 
-    <string name="files_shared_1">File: %s</string>
-    <string name="files_shared_2">Files: %s and %s</string>
-    <string name="files_shared_3">Files: %s and %d more</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -51,8 +51,9 @@
     <string name="warning_nothing_to_send">Nothing to send</string>
     <string name="mail_queued">Mail will be send when online</string>
 
-    <plurals name="files_shared">
-        <item quantity="one">File: %s</item>
+    <string name="subject_single_file">File: %s</string>
+    <plurals name="subject_multiple_files">
+        <item quantity="one">Files: %s and 1 more</item>
         <item quantity="other">Files: %s and %d more</item>
     </plurals>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -51,4 +51,9 @@
     <string name="warning_nothing_to_send">Nothing to send</string>
     <string name="mail_queued">Mail will be send when online</string>
 
+    <plurals name="files_shared">
+        <item quantity="one">File: %s</item>
+        <item quantity="other">Files: %s and %d more</item>
+    </plurals>
+
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -52,4 +52,7 @@
     <string name="warning_nothing_to_send">Nothing to send</string>
     <string name="mail_queued">Mail will be send when online</string>
 
+    <string name="files_shared_1">File: %s</string>
+    <string name="files_shared_2">Files: %s and %s</string>
+    <string name="files_shared_3">Files: %s and %d more</string>
 </resources>

--- a/src/de/grobox/blitzmail/send/SendActivity.java
+++ b/src/de/grobox/blitzmail/send/SendActivity.java
@@ -191,8 +191,13 @@ public class SendActivity extends AppCompatActivity {
 			if (filename.length() > MAX_FILENAME_LENGTH) {
 				filename = filename.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
 			}
-			jMail.put("subject", getResources().getQuantityString(
-				R.plurals.files_shared, count, filename, files.length() - 1));
+			if (files.length() == 1) {
+				jMail.put("subject", getString(R.string.subject_single_file, filename));
+			} else {
+				int over_one = files.length() - 1;
+				jMail.put("subject", getResources().getQuantityString(
+					R.plurals.subject_multiple_files, over_one, filename, over_one));
+			}
 		} catch(JSONException e) {
 			e.printStackTrace();
 		}

--- a/src/de/grobox/blitzmail/send/SendActivity.java
+++ b/src/de/grobox/blitzmail/send/SendActivity.java
@@ -75,7 +75,7 @@ public class SendActivity extends AppCompatActivity {
 	public static final String ACTION_RESEND = "BlitzMailReSend";
 	private static final int MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE = 42;
 	private static final int MAX_SUBJECT_LENGTH = 128;
-	private static final int MAX_FILENAME_LENGTH = 32;
+	private static final int MAX_FILENAME_LENGTH = 64;
 
 	@Override
 	protected void onCreate (Bundle savedInstanceState) {
@@ -187,29 +187,13 @@ public class SendActivity extends AppCompatActivity {
 
 		try {
 			JSONArray files = jMail.getJSONArray(MAIL_ATTACHMENTS);
-			if (files.length() == 1) {
-				String name1 = files.getJSONObject(0).getString("filename");
-				if (name1.length() > MAX_FILENAME_LENGTH) {
-					name1 = name1.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
-				}
-				jMail.put("subject", getString(R.string.files_shared_1, name1));
-			} else if (files.length() == 2) {
-				String name1 = files.getJSONObject(0).getString("filename");
-				String name2 = files.getJSONObject(1).getString("filename");
-				if (name1.length() > MAX_FILENAME_LENGTH) {
-					name1 = name1.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
-				}
-				if (name2.length() > MAX_FILENAME_LENGTH) {
-					name2 = name2.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
-				}
-				jMail.put("subject", getString(R.string.files_shared_2, name1, name2));
-			} else {
-				String name1 = files.getJSONObject(0).getString("filename");
-				if (name1.length() > MAX_FILENAME_LENGTH) {
-					name1 = name1.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
-				}
-				jMail.put("subject", getString(R.string.files_shared_3, name1, files.length() - 1));
+			int count = files.length();
+			String filename = files.getJSONObject(0).getString("filename");
+			if (filename.length() > MAX_FILENAME_LENGTH) {
+				filename = filename.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
 			}
+			jMail.put("subject", getResources().getQuantityString(
+					R.plurals.files_shared, count, count, count - 1, filename));
 		} catch(JSONException e) {
 			e.printStackTrace();
 		}

--- a/src/de/grobox/blitzmail/send/SendActivity.java
+++ b/src/de/grobox/blitzmail/send/SendActivity.java
@@ -192,10 +192,10 @@ public class SendActivity extends AppCompatActivity {
 				filename = filename.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
 			}
 			if (files.length() == 1) {
-				jMail.put("subject", getString(R.string.subject_single_file, filename));
+				jMail.put(MAIL_SUBJECT, getString(R.string.subject_single_file, filename));
 			} else {
 				int over_one = files.length() - 1;
-				jMail.put("subject", getResources().getQuantityString(
+				jMail.put(MAIL_SUBJECT, getResources().getQuantityString(
 					R.plurals.subject_multiple_files, over_one, filename, over_one));
 			}
 		} catch(JSONException e) {

--- a/src/de/grobox/blitzmail/send/SendActivity.java
+++ b/src/de/grobox/blitzmail/send/SendActivity.java
@@ -74,6 +74,8 @@ public class SendActivity extends AppCompatActivity {
 
 	public static final String ACTION_RESEND = "BlitzMailReSend";
 	private static final int MY_PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE = 42;
+	private static final int MAX_SUBJECT_LENGTH = 128;
+	private static final int MAX_FILENAME_LENGTH = 32;
 
 	@Override
 	protected void onCreate (Bundle savedInstanceState) {
@@ -136,7 +138,7 @@ public class SendActivity extends AppCompatActivity {
 			// Check for empty content
 			if(subject == null || subject.isEmpty()) {
 				// cut all characters from subject after the 128th
-				subject = text.substring(0, (text.length() < 128) ? text.length() : 128);
+				subject = text.substring(0, Math.min(text.length(), MAX_SUBJECT_LENGTH));
 				// remove line breaks from subject
 				subject = subject.replace("\n", " ").replace("\r", " ");
 			}
@@ -184,8 +186,30 @@ public class SendActivity extends AppCompatActivity {
 		}
 
 		try {
-			String num = String.valueOf(jMail.getJSONArray("attachments").length());
-			jMail.put("subject", num + " " + getString(R.string.files_shared) + " " + getString(R.string.app_name));
+			JSONArray files = jMail.getJSONArray(MAIL_ATTACHMENTS);
+			if (files.length() == 1) {
+				String name1 = files.getJSONObject(0).getString("filename");
+				if (name1.length() > MAX_FILENAME_LENGTH) {
+					name1 = name1.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
+				}
+				jMail.put("subject", getString(R.string.files_shared_1, name1));
+			} else if (files.length() == 2) {
+				String name1 = files.getJSONObject(0).getString("filename");
+				String name2 = files.getJSONObject(1).getString("filename");
+				if (name1.length() > MAX_FILENAME_LENGTH) {
+					name1 = name1.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
+				}
+				if (name2.length() > MAX_FILENAME_LENGTH) {
+					name2 = name2.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
+				}
+				jMail.put("subject", getString(R.string.files_shared_2, name1, name2));
+			} else {
+				String name1 = files.getJSONObject(0).getString("filename");
+				if (name1.length() > MAX_FILENAME_LENGTH) {
+					name1 = name1.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
+				}
+				jMail.put("subject", getString(R.string.files_shared_3, name1, files.length() - 1));
+			}
 		} catch(JSONException e) {
 			e.printStackTrace();
 		}

--- a/src/de/grobox/blitzmail/send/SendActivity.java
+++ b/src/de/grobox/blitzmail/send/SendActivity.java
@@ -187,13 +187,12 @@ public class SendActivity extends AppCompatActivity {
 
 		try {
 			JSONArray files = jMail.getJSONArray(MAIL_ATTACHMENTS);
-			int count = files.length();
 			String filename = files.getJSONObject(0).getString("filename");
 			if (filename.length() > MAX_FILENAME_LENGTH) {
 				filename = filename.substring(0, MAX_FILENAME_LENGTH - 2) + "…";
 			}
 			jMail.put("subject", getResources().getQuantityString(
-					R.plurals.files_shared, count, count, count - 1, filename));
+				R.plurals.files_shared, count, filename, files.length() - 1));
 		} catch(JSONException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
This is related to #28.

I went for the simplest possible, and while testing I found that a prefix was more intuitive than a suffix. We could even remove the prefix IMHO, the filename seems to be enough.

But I'd be happy to change the format to whatever is preferred, as were suggested before!

Examples of the new subjects:

Single file: `File: MY_FILE.png`
Two files:   `Files: MY_FILE.png and MY_FILE2.png`
More files:  `Files: MY_FILE.png and 3 more`
